### PR TITLE
UX: Links - color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -42,6 +42,12 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
+/* all links inside the text and lists */
+p > a,
+li > a {
+  color: var(--bbn-primary);
+}
+
 .navbar {
   background-color: rgb(251, 251, 251);
   color: #ff7c2b;


### PR DESCRIPTION
All links inside the text (paragraphs) and lists to have the Babylon primary color:
- Before: https://i.imgur.com/YAH47cM.png https://i.imgur.com/RlLI1XD.png
- After: https://i.imgur.com/fewy9yW.png https://i.imgur.com/eeqTVfe.png