### PR TITLE
fix(finality-provider): Inconsistency with code

### DIFF
--- a/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
@@ -69,10 +69,8 @@ Below are the `eotsd.conf` file contents:
 # Default address to listen for RPC connections
 RpcListener = 127.0.0.1:15813
 
-# Type of keyring to use,
-# supported backends - (os|file|kwallet|pass|test|memory)
-# ref https://docs.cosmos.network/v0.46/run-node/keyring.html#available-backends-for-the-keyring
-KeyringBackend = file
+# Type of keyring to use
+KeyringBackend = test
 
 # Possible database to choose as backend
 Backend = bbolt

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -81,9 +81,7 @@ GRPCAddr = https://127.0.0.1:9090
 # Name of the key in the keyring to use for signing transactions
 Key = <finality-provider-key-name>
 
-# Type of keyring to use,
-# supported backends - (os|file|kwallet|pass|test|memory)
-# ref https://docs.cosmos.network/v0.46/run-node/keyring.html#available-backends-for-the-keyring
+# Type of keyring to use
 KeyringBackend = test
 
 # Directory where keys will be retrieved from and stored


### PR DESCRIPTION
As we have keyring backend of `test` as the default value. This should be consistent with the docs