### PR TITLE
Incorporate validator feedback

### DIFF
--- a/docs/user-guides/btc-staking-testnet/become-btc-staker.md
+++ b/docs/user-guides/btc-staking-testnet/become-btc-staker.md
@@ -395,7 +395,7 @@ In the following, we go through important parameters of the `stakerd.conf` file.
 Key = btc-staker
 
 # Chain id of the chain (Babylon)
-ChainID = chain-test
+ChainID = bbn-test-3
 
 # Address of the chain's RPC server (Babylon)
 RPCAddr = http://localhost:26657
@@ -403,17 +403,8 @@ RPCAddr = http://localhost:26657
 # Address of the chain's GRPC server (Babylon)
 GRPCAddr = https://localhost:9090
 
-# Type of keyring backend to use 
-KeyringBackend = test
-
-# Adjustment factor when using gas estimation
-GasAdjustment = 1.2
-
-# Comma separated minimum gas prices to accept for transactions
-GasPrices = 0.01ubbn
-
 # Directory to store staker keys in
-KeyDirectory = /Users/<user>/Library/Application Support/Stakerd
+KeyDirectory = /path/to/stakerd-home/
 ```
 
 #### BTC Node configuration
@@ -652,3 +643,6 @@ db.
 ```bash
 stakercli daemon withdrawable-transactions
 ```
+
+In order to `unstake` you'll need to wait for your staking/unbonding tx to be deep
+enough in btc so that timelock expires.

--- a/docs/user-guides/btc-staking-testnet/become-btc-staker.md
+++ b/docs/user-guides/btc-staking-testnet/become-btc-staker.md
@@ -310,27 +310,12 @@ export PATH=$HOME/go/bin:$PATH
 echo 'export PATH=$HOME/go/bin:$PATH' >> ~/.profile
 ```
 
-To build without installing,
-
-```bash
-make build
-```
-
 ### Create a Babylon keyring (keyring backend: test) with funds
 
 The `stakerd` daemon requires a keyring with loaded Babylon tokens to pay for the
 transactions. Follow this
 [guide](https://docs.babylonchain.io/docs/user-guides/btc-staking-testnet/getting-funds)
 to create a keyring and request funds.
-
-The above command will put the built binaries in a build directory with the following
-structure:
-
-```bash
- ls build
-     ├── stakerd
-     └── stakercli
-```
 
 ## 4. BTC Staker Setup
 
@@ -502,7 +487,7 @@ You can start the staker daemon using the following command:
 stakerd
 ```
 
-This will start the RPC server at the address specified in the configuration under
+This will start the Staker daemon RPC server at the address specified in the configuration under
 the `RawRPCListeners` field. A custom address can also be specified using
 the `--rpclisten` flag.
 

--- a/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
@@ -71,10 +71,10 @@ You can start the EOTS daemon using the following command:
 eotsd start --home /path/to/eotsd/home
 ```
 
-This will start the rpc server at the address specified in the configuration
-file `eotsd.conf` under the `RpcListener` field, which has a default value
-of `127.0.0.1:12582`. You can change this value in the configuration file or override
-this value and specify a custom address using the `--rpc-listener` flag.
+This will start the EOTS rpc server at the address specified in `eotsd.conf` under
+the `RpcListener` field, which is by default set to `127.0.0.1:12582`. You can change
+this value in the configuration file or override this value and specify a custom
+address using the `--rpc-listener` flag.
 
 ```bash
 eotsd start

--- a/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
@@ -6,43 +6,43 @@ sidebar_label: EOTS Manager
 
 ## 1. Overview
 
-The EOTS daemon is responsible for managing EOTS keys,
-producing EOTS randomness, and using them to produce EOTS signatures.
+The EOTS daemon is responsible for managing EOTS keys, producing EOTS randomness, and
+using them to produce EOTS signatures.
 
 **Note:** EOTS stands for Extractable One Time Signature. You can read more about it
 in
 the [Babylon BTC Staking Litepaper](https://docs.babylonchain.io/assets/files/btc_staking_litepaper-32bfea0c243773f0bfac63e148387aef.pdf).
-In short, the EOTS manager produces EOTS public/private randomness pairs.
-The finality provider commits the public part of this pairs to Babylon for
-every future block height that they intend to provide a finality signature for.
-If the finality provider votes for two different blocks on the same height,
-they will have to reuse the same private randomness which will lead to their
-underlying private key being exposed, leading to the slashing of them and all their delegators.
+In short, the EOTS manager produces EOTS public/private randomness pairs. The
+finality provider commits the public part of this pairs to Babylon for every future
+block height that they intend to provide a finality signature for. If the finality
+provider votes for two different blocks on the same height, they will have to reuse
+the same private randomness which will lead to their underlying private key being
+exposed, leading to the slashing of them and all their delegators.
 
 The EOTS manager is responsible for the following operations:
+
 1. **EOTS Key Management:**
     - Generates [Schnorr](https://en.wikipedia.org/wiki/Schnorr_signature) key pairs
       for a given finality provider using the
       [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
       standard.
-    - Persists generated key pairs in the
-      internal Cosmos keyring.
+    - Persists generated key pairs in the internal Cosmos keyring.
 2. **Randomness Generation:**
     - Generates lists of EOTS randomness pairs based on the EOTS key, chainID, and
       block height.
     - The randomness is deterministically generated and tied to specific parameters.
 3. **Signature Generation:**
-    - Signs EOTS using the private key of the finality provider and the corresponding secret
-      randomness for a given chain at a specified height.
+    - Signs EOTS using the private key of the finality provider and the corresponding
+      secret randomness for a given chain at a specified height.
     - Signs Schnorr signatures using the private key of the finality provider.
 
 The EOTS manager functions as a daemon controlled by the `eotsd` tool.
 
 ## 2. Configuration
 
-The `eotsd init` command initializes a home directory for the EOTS
-manager. This directory is created in the default home location or in a location
-specified by the `--home` flag.
+The `eotsd init` command initializes a home directory for the EOTS manager. This
+directory is created in the default home location or in a location specified by
+the `--home` flag.
 
 ```bash
 eotsd init --home /path/to/eotsd/home/
@@ -56,31 +56,12 @@ ls /path/to/eotsd/home/
   ├── logs       # Eotsd logs
 ```
 
-If the `--home` flag is not specified, then the default home location will
-be used. For different operating systems, those are:
+If the `--home` flag is not specified, then the default home location will be used.
+For different operating systems, those are:
 
 - **MacOS** `~/Users/<username>/Library/Application Support/Eotsd`
 - **Linux** `~/.Eotsd`
 - **Windows** `C:\Users\<username>\AppData\Local\Eotsd`
-
-Below are the `eotsd.conf` file contents:
-
-```bash
-# Default address to listen for RPC connections
-RpcListener = 127.0.0.1:15813
-
-# Type of keyring to use
-KeyringBackend = test
-
-# Possible database to choose as backend
-Backend = bbolt
-
-# Path to the database
-Path = bbolt-eots.db
-
-# Name of the database
-Name = default
-```
 
 ## 3. Starting the EOTS Daemon
 
@@ -90,15 +71,16 @@ You can start the EOTS daemon using the following command:
 eotsd start --home /path/to/eotsd/home
 ```
 
-This will start the rpc server at the address specified in the configuration under
-the `RpcListener` field, which has a default value of `127.0.0.1:15813`.
-You can also specify a custom address using the `--rpc-listener` flag.
+This will start the rpc server at the address specified in the configuration
+file `eotsd.conf` under the `RpcListener` field, which has a default value
+of `127.0.0.1:12582`. You can change this value in the configuration file or override
+this value and specify a custom address using the `--rpc-listener` flag.
 
 ```bash
 eotsd start
 
-time="2023-11-26T16:35:04-05:00" level=info msg="RPC server listening	{"address": "127.0.0.1:15813"}"
-time="2023-11-26T16:35:04-05:00" level=info msg="EOTS Manager Daemon is fully active!"
+2024-02-08T17:59:11.467212Z	info	RPC server listening	{"address": "127.0.0.1:12582"}
+2024-02-08T17:59:11.467660Z	info	EOTS Manager Daemon is fully active!
 ```
 
 All the available cli options can be viewed using the `--help` flag. These options
@@ -107,5 +89,5 @@ can also be set in the configuration file.
 **Note**: It is recommended to run the `eotsd` daemon on a separate machine or
 network segment to enhance security. This helps isolate the key management
 functionality and reduces the potential attack surface. You can edit the
-`EOTSManagerAddress` in  the configuration file of the finality provider
-to reference the address of the machine where `eotsd` is running.
+`EOTSManagerAddress` in the configuration file of the finality provider to reference
+the address of the machine where `eotsd` is running.

--- a/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/eots-manager.md
@@ -71,6 +71,8 @@ You can start the EOTS daemon using the following command:
 eotsd start --home /path/to/eotsd/home
 ```
 
+If the `--home` flag is not specified, then the default home location will be used.
+
 This will start the EOTS rpc server at the address specified in `eotsd.conf` under
 the `RpcListener` field, which is by default set to `127.0.0.1:12582`. You can change
 this value in the configuration file or override this value and specify a custom

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -95,10 +95,10 @@ To see the complete list of configuration options, check the `fpd.conf` file.
    default value: 100 blocks)
 
    ```bash
-   ; The number of Schnorr public randomness for each commitment
+   # The number of Schnorr public randomness for each commitment
    NumPubRand = 100
 
-   ; The upper bound of the number of Schnorr public randomness for each commitment
+   # The upper bound of the number of Schnorr public randomness for each commitment
    NumPubRandMax = 200
    ```
 

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -122,10 +122,11 @@ Use the following command to add the key:
 ```bash
 fpd keys add --key-name my-finality-provider --chain-id bbn-test-3
 ```
+
+**Note**: Please use the same `--chain-id` value set in the `fpd.conf`.
+
 After executing the above command, the key name will be saved in the config file
 created in [step](#2-configuration).
-
-**Note**: Please use the same `--chain-id` value as the `ChainID` set in the `fpd.conf`
 
 ## 4. Starting the Finality Provider Daemon
 

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -6,35 +6,32 @@ sidebar_label: Finality Provider
 
 ## 1. Overview
 
-The Finality Provider Daemon is responsible for
-monitoring for new Babylon blocks,
-committing public randomness for the blocks it
-intends to provide finality signatures for, and
-submitting finality signatures.
+The Finality Provider Daemon is responsible for monitoring for new Babylon blocks,
+committing public randomness for the blocks it intends to provide finality signatures
+for, and submitting finality signatures.
 
-The daemon can manage and perform the following operations for multiple
-finality providers:
-1. **Creation and Registration**: Creates and registers finality
-   providers to Babylon.
-2. **EOTS Randomness Commitment**: The daemon monitors the Babylon chain and
-   commits EOTS public randomness for every Babylon block each
-   finality provider intends to vote for. The commit intervals can be specified
-   in the configuration.
-   The EOTS public randomness is retrieved through the finality provider daemon's
-   connection with the [EOTS daemon](./eots-manager.md).
-3. **Finality Votes Submission**: The daemon monitors the Babylon chain
-   and produces finality votes for each block each maintained finality provider
-   has committed to vote for.
+The daemon can manage and perform the following operations for multiple finality
+providers:
 
-The daemon is controlled by the `fpd` tool.
-The `fpcli` tool implements commands for interacting with the daemon.
+1. **Creation and Registration**: Creates and registers finality providers to
+   Babylon.
+2. **EOTS Randomness Commitment**: The daemon monitors the Babylon chain and commits
+   EOTS public randomness for every Babylon block each finality provider intends to
+   vote for. The commit intervals can be specified in the configuration. The EOTS
+   public randomness is retrieved through the finality provider daemon's connection
+   with the [EOTS daemon](./eots-manager.md).
+3. **Finality Votes Submission**: The daemon monitors the Babylon chain and produces
+   finality votes for each block each maintained finality provider has committed to
+   vote for.
+
+The daemon is controlled by the `fpd` tool. The `fpcli` tool implements commands for
+interacting with the daemon.
 
 ## 2. Configuration
 
-The `fpd init` command initializes a home directory for the
-finality provider daemon.
-This directory is created in the default home location or in a
-location specified by the `--home` flag.
+The `fpd init` command initializes a home directory for the finality provider daemon.
+This directory is created in the default home location or in a location specified by
+the `--home` flag.
 
 ```bash
 fpd init --home /path/to/fpd/home/
@@ -48,8 +45,8 @@ ls /path/to/fpd/home/
   ├── logs     # Fpd logs
 ```
 
-If the `--home` flag is not specified, then the default home directory
-will be used. For different operating systems, those are:
+If the `--home` flag is not specified, then the default home directory will be used.
+For different operating systems, those are:
 
 - **MacOS** `~/Users/<username>/Library/Application Support/Fpd`
 - **Linux** `~/.Fpd`
@@ -59,33 +56,34 @@ Below are some important parameters of the `fpd.conf` file.
 
 **Note**:
 The configuration below requires to point to the path where this keyring is
-stored `KeyDirectory`. This `Key` field stores the key name used for
-interacting with the consumer chain and will be specified along with the
-`KeyringBackend` field in the next [step](#3-add-key-for-the-consumer-chain).
-So we can ignore the setting of the two fields in this step.
+stored `KeyDirectory`. This `Key` field stores the key name used for interacting with
+the consumer chain and will be specified along with the
+`KeyringBackend` field in the next [step](#3-add-key-for-the-consumer-chain). So we
+can ignore the setting of the two fields in this step.
 
 ```bash
+[Application Options]
 # RPC Address of the EOTS Daemon
-EOTSManagerAddress = 127.0.0.1:15813
+EOTSManagerAddress = 127.0.0.1:12582
 
-# Babylon specific parameters
+# RPC Address of the Finality Provider Daemon
+RpcListener = 127.0.0.1:12581
 
-# Babylon chain ID
-ChainID = chain-test
-
-# Babylon node RPC endpoint
-RPCAddr = http://127.0.0.1:26657
-
-# Babylon node gRPC endpoint
-GRPCAddr = https://127.0.0.1:9090
-
-# Name of the key in the keyring to use for signing transactions
+[babylon]
+# Name of the key to sign transactions with
 Key = <finality-provider-key-name>
 
-# Type of keyring to use
-KeyringBackend = test
+# Chain id of the chain to connect to
+# Please confirm the Babylon Chain ID from our rpc node. https://rpc.testnet3.babylonchain.io/status
+ChainID = bbn-test-3
 
-# Directory where keys will be retrieved from and stored
+# RPC Address of Babylon node
+RPCAddr = http://127.0.0.1:26657
+
+# GRPC Address of Babylon node
+GRPCAddr = https://127.0.0.1:9090
+
+# Directory to store keys in
 KeyDirectory = /path/to/fpd/home
 ```
 
@@ -93,15 +91,15 @@ To see the complete list of configuration options, check the `fpd.conf` file.
 
 **Additional Notes:**
 
-1. We strongly recommend that EOTS randomness commitments are limited to 500
-   blocks (default value: 100 blocks)
+1. We strongly recommend that EOTS randomness commitments are limited to 500 blocks (
+   default value: 100 blocks)
 
    ```bash
    ; The number of Schnorr public randomness for each commitment
    NumPubRand = 100
 
    ; The upper bound of the number of Schnorr public randomness for each commitment
-   NumPubRandMax = 100
+   NumPubRandMax = 200
    ```
 
 2. If you encounter any gas-related errors while performing staking operations,
@@ -115,9 +113,9 @@ To see the complete list of configuration options, check the `fpd.conf` file.
 
 ## 3. Add key for the consumer chain
 
-The finality provider daemon requires the existence of a keyring that contains
-an account with Babylon token funds to pay for transactions.
-This key will be also used to pay for fees of transactions to the consumer chain.
+The finality provider daemon requires the existence of a keyring that contains an
+account with Babylon token funds to pay for transactions. This key will be also used
+to pay for fees of transactions to the consumer chain.
 
 Use the following command to add the key:
 
@@ -136,38 +134,38 @@ You can start the finality provider daemon using the following command:
 fpd start --home /path/to/fpd/home
 ```
 
-This will start the RPC server at the address specified in the configuration
-under the `RpcListener` field, which has a default value of `127.0.0.1:15812`.
-You can also specify a custom address using the `--rpc-listener` flag.
+This will start the Finality provider RPC server at the address specified
+in `fpd.conf` under the `RpcListener` field, which has a default value
+of `127.0.0.1:12581`. You can change this value in the configuration file or override
+this value and specify a custom address using the `--rpc-listener` flag.
 
 This will also start all the registered finality provider instances except for
-slashed ones added in [step](#5-create-and-register-a-finality-provider).
-To start the daemon with a specific finality provider instance, use the
-`--btc-pk` flag followed by the hex string of the BTC public key of the
-finality provider (`btc_pk_hex`) obtained in [step](#5-create-and-register-a-finality-provider).
+slashed ones added in [step](#5-create-and-register-a-finality-provider). To start
+the daemon with a specific finality provider instance, use the
+`--btc-pk` flag followed by the hex string of the BTC public key of the finality
+provider (`btc_pk_hex`) obtained
+in [step](#5-create-and-register-a-finality-provider).
 
 ```bash
-fpd start --rpc-listener '127.0.0.1:8088'
+fpd start
 
-time="2023-11-26T16:37:00-05:00" level=info msg="successfully connected to a remote EOTS manager	{"address": "127.0.0.1:15813"}"
-time="2023-11-26T16:37:00-05:00" level=info msg="Starting FinalityProviderApp"
-time="2023-11-26T16:37:00-05:00" level=info msg="Starting RPC Server"
-time="2023-11-26T16:37:00-05:00" level=info msg="RPC server listening	{"address": "127.0.0.1:15812"}"
-time="2023-11-26T16:37:00-05:00" level=info msg="Finality Provider Daemon is fully active!"
+2024-02-08T18:43:00.705008Z info successfully connected to a remote EOTS manager {"address": "127.0.0.1:12582"}
+2024-02-08T18:43:00.712995Z info Starting FinalityProviderApp
+2024-02-08T18:43:00.716682Z info RPC server listening {"address": "127.0.0.1:12581"}
+2024-02-08T18:43:00.716979Z info Finality Provider Daemon is fully active!
 ```
 
-All the available CLI options can be viewed using the `--help` flag.
-These options can also be set in the configuration file.
+All the available CLI options can be viewed using the `--help` flag. These options
+can also be set in the configuration file.
 
 ## 5. Create and Register a Finality Provider
 
 We create a finality provider instance through the
-`fpcli create-finality-provider` or `fpcli cfp` command.
-The created instance is associated with a BTC public key which
-serves as its unique identifier and
-a Babylon account to which staking rewards will be directed.
-Note that if the `--key-name` flag is not specified, the `Key` field of
-config specified in [step](#3-add-key-for-the-consumer-chain) will be used.
+`fpcli create-finality-provider` or `fpcli cfp` command. The created instance is
+associated with a BTC public key which serves as its unique identifier and a Babylon
+account to which staking rewards will be directed. Note that if the `--key-name` flag
+is not specified, the `Key` field of config specified
+in [step](#3-add-key-for-the-consumer-chain) will be used.
 
 ```bash
 fpcli create-finality-provider --key-name my-finality-provider \
@@ -183,32 +181,32 @@ fpcli create-finality-provider --key-name my-finality-provider \
 ```
 
 We register a created finality provider in Babylon through
-the `fpcli register-finality-provider` or `fpcli rfp` command.
-The output contains the hash of the Babylon finality provider registration
-transaction.
+the `fpcli register-finality-provider` or `fpcli rfp` command. The output contains
+the hash of the Babylon finality provider registration transaction.
 
 ```bash
 fpcli register-finality-provider \
-      --btc-pk d0fc4db48643fbb4339dc4bbf15f272411716b0d60f18bdfeb3861544bf5ef63
+  --btc-pk d0fc4db48643fbb4339dc4bbf15f272411716b0d60f18bdfeb3861544bf5ef63
 {
-    "tx_hash": "800AE5BBDADE974C5FA5BD44336C7F1A952FAB9F5F9B43F7D4850BA449319BAA"
+  "tx_hash": "800AE5BBDADE974C5FA5BD44336C7F1A952FAB9F5F9B43F7D4850BA449319BAA"
 }
+
 ```
 
-A finality provider instance will be initiated and start running right after
-the finality provider is successfully registered in Babylon.
+A finality provider instance will be initiated and start running right after the
+finality provider is successfully registered in Babylon.
 
 We can view the status of all the running finality providers through
-the `fpcli list-finality-providers` or `fpcli ls` command.
-The `status` field can receive the following values:
+the `fpcli list-finality-providers` or `fpcli ls` command. The `status` field can
+receive the following values:
 
 - `CREATED`: The finality provider is created but not registered yet
-- `REGISTERED`: The finality provider is registered but has not received any
-  active delegations yet
-- `ACTIVE`: The finality provider has active delegations and is empowered to
-  send finality signatures
-- `INACTIVE`: The finality provider used to be ACTIVE but the voting power is
-  reduced to zero
+- `REGISTERED`: The finality provider is registered but has not received any active
+  delegations yet
+- `ACTIVE`: The finality provider has active delegations and is empowered to send
+  finality signatures
+- `INACTIVE`: The finality provider used to be ACTIVE but the voting power is reduced
+  to zero
 - `SLASHED`: The finality provider is slashed due to malicious behavior
 
 ```bash

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -134,6 +134,8 @@ You can start the finality provider daemon using the following command:
 fpd start --home /path/to/fpd/home
 ```
 
+If the `--home` flag is not specified, then the default home location will be used.
+
 This will start the Finality provider RPC server at the address specified
 in `fpd.conf` under the `RpcListener` field, which has a default value
 of `127.0.0.1:12581`. You can change this value in the configuration file or override

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -91,25 +91,13 @@ To see the complete list of configuration options, check the `fpd.conf` file.
 
 **Additional Notes:**
 
-1. We strongly recommend that EOTS randomness commitments are limited to 500 blocks (
-   default value: 100 blocks)
+If you encounter any gas-related errors while performing staking operations, consider
+adjusting the `GasAdjustment` and `GasPrices` parameters. For example, you can set:
 
-   ```bash
-   # The number of Schnorr public randomness for each commitment
-   NumPubRand = 100
-
-   # The upper bound of the number of Schnorr public randomness for each commitment
-   NumPubRandMax = 200
-   ```
-
-2. If you encounter any gas-related errors while performing staking operations,
-   consider adjusting the `GasAdjustment` and `GasPrices` parameters. For example,
-   you can set:
-
-   ```bash
-   GasAdjustment = 1.5
-   GasPrices = 0.002ubbn
-   ```
+```bash
+GasAdjustment = 1.5
+GasPrices = 0.002ubbn
+```
 
 ## 3. Add key for the consumer chain
 
@@ -123,7 +111,8 @@ Use the following command to add the key:
 fpd keys add --key-name my-finality-provider --chain-id bbn-test-3
 ```
 
-**Note**: Please verify the `chain-id` from the Babylon RPC node https://rpc.testnet3.babylonchain.io/status
+**Note**: Please verify the `chain-id` from the Babylon RPC
+node https://rpc.testnet3.babylonchain.io/status
 
 After executing the above command, the key name will be saved in the config file
 created in [step](#2-configuration).

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -120,11 +120,12 @@ to pay for fees of transactions to the consumer chain.
 Use the following command to add the key:
 
 ```bash
-fpd keys add --key-name my-finality-provider --chain-id chain-test
+fpd keys add --key-name my-finality-provider --chain-id bbn-test-3
 ```
-
 After executing the above command, the key name will be saved in the config file
 created in [step](#2-configuration).
+
+**Note**: Please use the same `--chain-id` value as the `ChainID` set in the `fpd.conf`
 
 ## 4. Starting the Finality Provider Daemon
 

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -108,7 +108,7 @@ To see the complete list of configuration options, check the `fpd.conf` file.
 
    ```bash
    GasAdjustment = 1.5
-   GasPrices = 0.01ubbn
+   GasPrices = 0.002ubbn
    ```
 
 ## 3. Add key for the consumer chain

--- a/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/finality-provider.md
@@ -74,7 +74,7 @@ RpcListener = 127.0.0.1:12581
 Key = <finality-provider-key-name>
 
 # Chain id of the chain to connect to
-# Please confirm the Babylon Chain ID from our rpc node. https://rpc.testnet3.babylonchain.io/status
+# Please verify the `ChainID` from the Babylon RPC node https://rpc.testnet3.babylonchain.io/status
 ChainID = bbn-test-3
 
 # RPC Address of Babylon node
@@ -123,7 +123,7 @@ Use the following command to add the key:
 fpd keys add --key-name my-finality-provider --chain-id bbn-test-3
 ```
 
-**Note**: Please use the same `--chain-id` value set in the `fpd.conf`.
+**Note**: Please verify the `chain-id` from the Babylon RPC node https://rpc.testnet3.babylonchain.io/status
 
 After executing the above command, the key name will be saved in the config file
 created in [step](#2-configuration).
@@ -173,7 +173,7 @@ in [step](#3-add-key-for-the-consumer-chain) will be used.
 
 ```bash
 fpcli create-finality-provider --key-name my-finality-provider \
-                --chain-id chain-test --moniker my-name
+                --chain-id bbn-test-3 --moniker my-name
 {
     "babylon_pk_hex": "02face5996b2792114677604ec9dfad4fe66eeace3df92dab834754add5bdd7077",
     "btc_pk_hex": "d0fc4db48643fbb4339dc4bbf15f272411716b0d60f18bdfeb3861544bf5ef63",

--- a/docs/user-guides/btc-staking-testnet/finality-providers/overview.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/overview.md
@@ -84,21 +84,6 @@ export PATH=$HOME/go/bin:$PATH
 echo 'export PATH=$HOME/go/bin:$PATH' >> ~/.profile
 ```
 
-To build without installing,
-
-```bash
-make build
-```
-
-The above command will put the built binaries in a build directory with the
-following structure:
-```bash
-ls build
-    ├── eotsd
-    ├── fpcli
-    └── fpd
-```
-
 ## 3. Setting up a finality provider
 
 ### 3.1. Setting up a Babylon Full Node

--- a/docs/user-guides/btc-staking-testnet/finality-providers/overview.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/overview.md
@@ -38,14 +38,14 @@ The following graphic demonstrates the interconnections between the above progra
 
 ## 2. Installation
 
-#### Prerequisites
+### Prerequisites
 
 This project requires Go version 1.21 or later.
 
 Install Go by following the instructions on
 the [official Go installation guide](https://golang.org/doc/install).
 
-#### Downloading the code
+### Downloading the code
 
 To get started, clone the repository to your local machine from Github:
 
@@ -61,7 +61,7 @@ cd finality-provider # cd into the project directory
 git checkout <release-tag>
 ```
 
-#### Building and installing the binary
+### Building and installing the binary
 
 At the top-level directory of the project
 
@@ -101,7 +101,7 @@ ls build
 
 ## 3. Setting up a finality provider
 
-#### 3.1. Setting up a Babylon Full Node
+### 3.1. Setting up a Babylon Full Node
 
 Before setting up the finality provider toolset,
 an operator must ensure a working connection with a Babylon full node.
@@ -115,7 +115,7 @@ in order to be able to send transactions to Babylon.
 To setup such a keyring, follow the instructions in
 [the Babylon documentation](https://docs.babylonchain.io/docs/user-guides/btc-timestamping-testnet/getting-funds).
 
-#### 3.2. Setting up the EOTS Manager
+### 3.2. Setting up the EOTS Manager
 
 After a node and a keyring have been set up,
 the operator can set up and run the
@@ -124,7 +124,7 @@ A complete overview of the EOTS manager, its operation, and
 its configuration options can be found in the
 [EOTS Manager page](./eots-manager.md)
 
-#### 3.3. Setting up a Finality Provider 
+### 3.3. Setting up a Finality Provider 
 
 The last step is to set up and run
 the finality daemon.

--- a/docs/user-guides/btc-staking-testnet/integrate.md
+++ b/docs/user-guides/btc-staking-testnet/integrate.md
@@ -115,7 +115,7 @@ chains:
             # REPLACEME: The Chain ID of the Babylon network you want to connect to.
             #            For example, for the current testnet, this is `bbn-test-2`
             #            Note that this chain ID should be the same one you used for creating the keyring.
-            chain-id: bbn-test-2
+            chain-id: bbn-test-3
             # REPLACEME: The RPC endpoint of a node that runs on the Babylon network you want to connect to.
             rpc-addr: https://rpc.testnet3.babylonchain.io:443
             account-prefix: bbn
@@ -146,7 +146,7 @@ paths:
         # Chain IDs that this path will connect
         # REPLACEME: Use the chain IDs For Babylon and the integrated chain you specified above.
         src:
-            chain-id: bbn-test-2
+            chain-id: bbn-test-3
         dst:
             chain-id: osmo-test-4
 ```


### PR DESCRIPTION
This pr
- Removes information about make build - people seem to be getitng confused b/w make build and make install. We will only show make install now
- Fix chain id everywhere and mention actual id i.e bbn-test-3. Also mention a note to verify the chain id from our rpc node. 
- Fix formatting
- Fixes inconsistencies in actual config and config examples in docs. This was mostly in finality provider page.


Notes - 
I have some confusion regarding note regarding randomness committment and its upper bound to 500 blocks [here](https://github.com/babylonchain/babylonchain.github.io/pull/65/files#diff-b76bc014d383f92130f4be32e0d59cddf746952d8f3b5710db170f44a0f4d841R94) 

Also the fpd.conf has this line, I had some doubt - so by default it is filled when we `fpd init` but the comments suggest to leave it empty. 

```
; The address of the remote EOTS manager; Empty if the EOTS manager is running locally
EOTSManagerAddress = 127.0.0.1:12582
```
cc @gitferry 