### PR TITLE
Remove redundant key creation in finality providers

### DIFF
--- a/docs/user-guides/btc-staking-testnet/finality-providers/overview.md
+++ b/docs/user-guides/btc-staking-testnet/finality-providers/overview.md
@@ -95,11 +95,6 @@ trusting third parties. Instructions on how to set up a full Babylon node
 can be found in 
 [the Babylon documentation](https://docs.babylonchain.io/docs/user-guides/btc-timestamping-testnet/setup-node).
 
-The finality provider requires a Babylon keyring with loaded funds to be attached to it
-in order to be able to send transactions to Babylon.
-To setup such a keyring, follow the instructions in
-[the Babylon documentation](https://docs.babylonchain.io/docs/user-guides/btc-timestamping-testnet/getting-funds).
-
 ### 3.2. Setting up the EOTS Manager
 
 After a node and a keyring have been set up,


### PR DESCRIPTION
The users first create a keyring when setting up full node, then they come to this overview page and notice a mention about keyring again. Finally when they run the commands `fpd keys add` create another keyring. This is creating some confusion. 

Also check https://github.com/babylonchain/finality-provider/pull/242