### PR TITLE
Add cometbft to run-node docs

### DIFF
--- a/docs/user-guides/btc-staking-testnet/setup-node.md
+++ b/docs/user-guides/btc-staking-testnet/setup-node.md
@@ -136,3 +136,9 @@ You can check the status of the node by running
 ```console
 systemctl status babylond
 ```
+
+## 5. Running node in production environment
+
+When running the Babylon node in a production setting, operators should adhere to 
+[CometBFT Guidelines](https://docs.cometbft.com/v0.38/core/running-in-production)
+


### PR DESCRIPTION
I did not find better place for this, as imo this docs should be linked near the instructions to run the node.